### PR TITLE
Add a new "Gradients" scene to Color Correction and Tone Mapping

### DIFF
--- a/3d/tonemap_color_correction/3d_primitives.tscn
+++ b/3d/tonemap_color_correction/3d_primitives.tscn
@@ -1,0 +1,261 @@
+[gd_scene load_steps=26 format=3 uid="uid://bfbqknlrqre0c"]
+
+[ext_resource type="Script" path="res://test_scene.gd" id="1_vpdan"]
+
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_y6uuk"]
+sky_top_color = Color(0, 0, 0, 1)
+sky_horizon_color = Color(0.1984, 0.242987, 0.32, 1)
+ground_bottom_color = Color(0.156863, 0.160784, 0.2, 1)
+ground_horizon_color = Color(0.156863, 0.160784, 0.2, 1)
+sun_angle_max = 6.0
+sun_curve = 3.51379
+
+[sub_resource type="Sky" id="Sky_lexvt"]
+sky_material = SubResource("ProceduralSkyMaterial_y6uuk")
+
+[sub_resource type="Environment" id="Environment_lqw28"]
+background_mode = 2
+sky = SubResource("Sky_lexvt")
+tonemap_mode = 2
+tonemap_white = 6.0
+glow_enabled = true
+glow_intensity = 0.09
+glow_blend_mode = 1
+fog_enabled = true
+fog_density = 0.025
+fog_aerial_perspective = 1.0
+adjustment_enabled = true
+
+[sub_resource type="BoxMesh" id="BoxMesh_ff240"]
+size = Vector3(512, 1, 512)
+
+[sub_resource type="Gradient" id="Gradient_sho7j"]
+offsets = PackedFloat32Array(0.260163, 0.398374, 0.536585, 0.699187, 0.829268, 1)
+colors = PackedColorArray(0.336608, 0.336608, 0.336608, 1, 0.589096, 0.589095, 0.589096, 1, 0.521141, 0.52114, 0.521141, 1, 0.762404, 0.762404, 0.762403, 1, 0.48179, 0.48179, 0.481789, 1, 1, 1, 1, 1)
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_dm8vr"]
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_hbgko"]
+width = 1024
+height = 1024
+seamless = true
+color_ramp = SubResource("Gradient_sho7j")
+noise = SubResource("FastNoiseLite_dm8vr")
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_mq5hl"]
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_tdt10"]
+width = 1024
+height = 1024
+seamless = true
+as_normal_map = true
+bump_strength = 10.0
+noise = SubResource("FastNoiseLite_mq5hl")
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4ldfp"]
+albedo_texture = SubResource("NoiseTexture2D_hbgko")
+normal_enabled = true
+normal_texture = SubResource("NoiseTexture2D_tdt10")
+uv1_scale = Vector3(512, 256, 1)
+texture_filter = 5
+
+[sub_resource type="BoxMesh" id="BoxMesh_6wvpc"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_l4mxj"]
+albedo_color = Color(0, 0, 0, 1)
+emission_enabled = true
+emission = Color(2, 1.5, 1, 1)
+
+[sub_resource type="SphereMesh" id="SphereMesh_qnmea"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kssqo"]
+metallic = 1.0
+roughness = 0.0
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4geml"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3eq2w"]
+metallic = 1.0
+roughness = 0.5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_uqci1"]
+albedo_color = Color(0.501961, 0.501961, 0.501961, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8sl4i"]
+albedo_color = Color(0.501961, 0.501961, 0.501961, 1)
+metallic = 1.0
+roughness = 0.5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pauuc"]
+albedo_color = Color(1, 0.25098, 0.25098, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8w4e2"]
+albedo_color = Color(1, 0.25098, 0.25098, 1)
+metallic = 1.0
+roughness = 0.5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_cb5og"]
+albedo_color = Color(0.25098, 1, 0.25098, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ah8ww"]
+albedo_color = Color(0.25098, 1, 0.25098, 1)
+metallic = 1.0
+roughness = 0.5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ako3b"]
+albedo_color = Color(0.25098, 0.25098, 1, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_suuj5"]
+albedo_color = Color(0.25098, 0.25098, 1, 1)
+metallic = 1.0
+roughness = 0.5
+
+[node name="3DPrimitives" type="Node3D" node_paths=PackedStringArray("world_environment")]
+script = ExtResource("1_vpdan")
+world_environment = NodePath("WorldEnvironment")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(0.866126, 0.13782, -0.480448, 0.0352591, 0.941991, 0.333781, 0.49858, -0.306037, 0.811024, -2.58974, 2.10013, -4.66397)
+light_color = Color(0.776471, 0.917647, 1, 1)
+light_energy = 0.4
+shadow_enabled = true
+shadow_bias = 0.04
+shadow_blur = 2.0
+directional_shadow_mode = 0
+directional_shadow_fade_start = 1.0
+directional_shadow_max_distance = 12.0
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_lqw28")
+
+[node name="Ground" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, -0.4, 1)
+mesh = SubResource("BoxMesh_ff240")
+surface_material_override/0 = SubResource("StandardMaterial3D_4ldfp")
+
+[node name="Testers" type="Node3D" parent="."]
+
+[node name="GlowingBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_l4mxj")
+
+[node name="OmniLight3D" type="OmniLight3D" parent="Testers/GlowingBox"]
+light_energy = 2.0
+shadow_blur = 2.0
+
+[node name="GlowingSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_l4mxj")
+
+[node name="OmniLight3D" type="OmniLight3D" parent="Testers/GlowingSphere"]
+light_energy = 2.0
+shadow_blur = 2.0
+
+[node name="MirrorSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_kssqo")
+
+[node name="WhiteBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_4geml")
+
+[node name="WhiteSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_4geml")
+
+[node name="WhiteMetallicSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_3eq2w")
+
+[node name="GrayBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_uqci1")
+
+[node name="GraySphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_uqci1")
+
+[node name="GrayMetallicSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_8sl4i")
+
+[node name="RedBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_pauuc")
+
+[node name="RedSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_pauuc")
+
+[node name="RedMetallicSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_8w4e2")
+
+[node name="GreenBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_cb5og")
+
+[node name="GreenSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_cb5og")
+
+[node name="GreenMetallicSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_ah8ww")
+
+[node name="BlueBox" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0.5, 0)
+mesh = SubResource("BoxMesh_6wvpc")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_ako3b")
+
+[node name="BlueSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1.5, 0)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_ako3b")
+
+[node name="BlueMetallicSphere" type="MeshInstance3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 2.5, -1)
+mesh = SubResource("SphereMesh_qnmea")
+skeleton = NodePath("../..")
+surface_material_override/0 = SubResource("StandardMaterial3D_suuj5")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(0.942327, -0.0710023, 0.327076, 6.57846e-09, 0.977239, 0.212141, -0.334694, -0.199906, 0.920879, 0.669204, 2.35, 4.04922)
+fov = 50.0
+
+[node name="ReflectionProbe" type="ReflectionProbe" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 2, 0)
+size = Vector3(512, 512, 512)
+enable_shadows = true

--- a/3d/tonemap_color_correction/gradients.tscn
+++ b/3d/tonemap_color_correction/gradients.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=33 format=3 uid="uid://drmdg7kgtgadn"]
+[gd_scene load_steps=32 format=3 uid="uid://drmdg7kgtgadn"]
 
 [ext_resource type="Script" path="res://test_scene.gd" id="1_t2d15"]
 [ext_resource type="PackedScene" uid="uid://bavd54phmfgyh" path="res://gradients/gradient_bars.tscn" id="2_p2qnr"]
 [ext_resource type="Shader" path="res://gradients/gradient_steps.gdshader" id="3_28j7b"]
 [ext_resource type="Script" path="res://gradients/gradients_controls.gd" id="4_fust6"]
-[ext_resource type="Script" path="res://gradients/gradients_custom_color.gd" id="5_kn8ml"]
 
 [sub_resource type="Environment" id="Environment_lqw28"]
 background_mode = 1
@@ -22,156 +21,182 @@ render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0, 0, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_eljuh"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0, 0, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_81w4g"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.0392157, 0.0392157, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ots2d"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.0392157, 0.0392157, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_41i5d"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.501961, 0.0392157, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_j0kf1"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.501961, 0.0392157, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_smq08"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.0392157, 0.501961, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_w135p"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(1, 0.0392157, 0.501961, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2wh7i"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0, 1, 0, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_xj3wk"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0, 1, 0, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ttmyv"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 1, 0.0392157, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_g72v6"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 1, 0.0392157, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_wjnjt"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 1, 0.0392157, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_wm7wm"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 1, 0.0392157, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_7d5gp"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 1, 0.501961, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_115u5"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 1, 0.501961, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_g82jm"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0, 0, 1, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ceq2s"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0, 0, 1, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_tg3s4"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 0.0392157, 1, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_xss0p"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 0.0392157, 1, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_w3opq"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 0.0392157, 1, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_qwbip"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 0.0392157, 1, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_x3aop"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 0.501961, 1, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_j2m03"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.0392157, 0.501961, 1, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2llro"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 0.501961, 0.501961, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_es2ea"]
 render_priority = 0
 shader = ExtResource("3_28j7b")
 shader_parameter/my_color = Color(0.501961, 0.501961, 0.501961, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [node name="Gradients" type="Node3D" node_paths=PackedStringArray("world_environment")]
 script = ExtResource("1_t2d15")
@@ -330,21 +355,24 @@ material_override = SubResource("ShaderMaterial_es2ea")
 [node name="Label3D" parent="Gradients_Custom" index="2"]
 text = "#808080"
 
-[node name="StepsControls" type="HBoxContainer" parent="." node_paths=PackedStringArray("max_value_label")]
-offset_left = 937.0
-offset_top = 85.0
-offset_right = 1137.0
-offset_bottom = 125.0
+[node name="Controls" type="Node" parent="." node_paths=PackedStringArray("max_value_label", "custom_bar")]
 script = ExtResource("4_fust6")
 bars = Array[NodePath]([NodePath("../Gradients_White"), NodePath("../Gradients_Red"), NodePath("../Gradients_Red2"), NodePath("../Gradients_Red3"), NodePath("../Gradients_Red4"), NodePath("../Gradients_Green"), NodePath("../Gradients_Green2"), NodePath("../Gradients_Green3"), NodePath("../Gradients_Green4"), NodePath("../Gradients_Blue"), NodePath("../Gradients_Blue2"), NodePath("../Gradients_Blue3"), NodePath("../Gradients_Blue4"), NodePath("../Gradients_Custom")])
 max_value_label = NodePath("../Label3D4")
 colors = Array[Color]([Color(1, 1, 1, 1), Color(1, 0, 0, 1), Color(1, 0.0392157, 0.0392157, 1), Color(1, 0.501961, 0.0392157, 1), Color(1, 0.0392157, 0.501961, 1), Color(0, 1, 0, 1), Color(0.0392157, 1, 0.0392157, 1), Color(0.501961, 1, 0.0392157, 1), Color(0.0392157, 1, 0.501961, 1), Color(0, 0, 1, 1), Color(0.0392157, 0.0392157, 1, 1), Color(0.501961, 0.0392157, 1, 1), Color(0.0392157, 0.501961, 1, 1)])
+custom_bar = NodePath("../Gradients_Custom")
 
-[node name="Label" type="Label" parent="StepsControls"]
+[node name="StepsControls" type="HBoxContainer" parent="Controls"]
+offset_left = 937.0
+offset_top = 85.0
+offset_right = 1137.0
+offset_bottom = 125.0
+
+[node name="Label" type="Label" parent="Controls/StepsControls"]
 layout_mode = 2
 text = "Max Value"
 
-[node name="Steps" type="HSlider" parent="StepsControls"]
+[node name="Steps" type="HSlider" parent="Controls/StepsControls"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
@@ -352,26 +380,30 @@ min_value = 1.0
 max_value = 20.0
 value = 6.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="." node_paths=PackedStringArray("custom_bar")]
+[node name="HBoxContainer" type="HBoxContainer" parent="Controls"]
 offset_left = 14.0
 offset_top = 604.0
-offset_right = 229.0
+offset_right = 420.0
 offset_bottom = 644.0
 theme_override_constants/separation = 10
-script = ExtResource("5_kn8ml")
-custom_bar = NodePath("../Gradients_Custom")
 
-[node name="Label" type="Label" parent="HBoxContainer"]
+[node name="Exponential" type="CheckButton" parent="Controls/HBoxContainer"]
+layout_mode = 2
+tooltip_text = "Uses a power 2 exponential function. This allows for easier viewing of the darker range of values."
+text = "Exponential Scale"
+
+[node name="Label" type="Label" parent="Controls/HBoxContainer"]
 layout_mode = 2
 text = "Custom Color"
 
-[node name="ColorPickerButton" type="ColorPickerButton" parent="HBoxContainer"]
+[node name="ColorPickerButton" type="ColorPickerButton" parent="Controls/HBoxContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 color = Color(0.501961, 0.501961, 0.501961, 1)
 
-[connection signal="value_changed" from="StepsControls/Steps" to="StepsControls" method="_on_steps_value_changed"]
-[connection signal="color_changed" from="HBoxContainer/ColorPickerButton" to="HBoxContainer" method="_on_color_picker_button_color_changed"]
+[connection signal="value_changed" from="Controls/StepsControls/Steps" to="Controls" method="_on_steps_value_changed"]
+[connection signal="toggled" from="Controls/HBoxContainer/Exponential" to="Controls" method="_on_exponential_toggled"]
+[connection signal="color_changed" from="Controls/HBoxContainer/ColorPickerButton" to="Controls" method="_on_color_picker_button_color_changed"]
 
 [editable path="Gradients_White"]
 [editable path="Gradients_Red"]

--- a/3d/tonemap_color_correction/gradients.tscn
+++ b/3d/tonemap_color_correction/gradients.tscn
@@ -1,0 +1,389 @@
+[gd_scene load_steps=33 format=3 uid="uid://drmdg7kgtgadn"]
+
+[ext_resource type="Script" path="res://test_scene.gd" id="1_t2d15"]
+[ext_resource type="PackedScene" uid="uid://bavd54phmfgyh" path="res://gradients/gradient_bars.tscn" id="2_p2qnr"]
+[ext_resource type="Shader" path="res://gradients/gradient_steps.gdshader" id="3_28j7b"]
+[ext_resource type="Script" path="res://gradients/gradients_controls.gd" id="4_fust6"]
+[ext_resource type="Script" path="res://gradients/gradients_custom_color.gd" id="5_kn8ml"]
+
+[sub_resource type="Environment" id="Environment_lqw28"]
+background_mode = 1
+background_energy_multiplier = 0.0
+ambient_light_source = 1
+reflected_light_source = 1
+tonemap_white = 6.0
+glow_intensity = 0.09
+glow_blend_mode = 1
+fog_density = 0.025
+adjustment_enabled = true
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_bstc8"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0, 0, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_eljuh"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0, 0, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_81w4g"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.0392157, 0.0392157, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ots2d"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.0392157, 0.0392157, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_41i5d"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.501961, 0.0392157, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_j0kf1"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.501961, 0.0392157, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_smq08"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.0392157, 0.501961, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_w135p"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(1, 0.0392157, 0.501961, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_2wh7i"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0, 1, 0, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_xj3wk"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0, 1, 0, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ttmyv"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 1, 0.0392157, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_g72v6"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 1, 0.0392157, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_wjnjt"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 1, 0.0392157, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_wm7wm"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 1, 0.0392157, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_7d5gp"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 1, 0.501961, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_115u5"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 1, 0.501961, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_g82jm"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0, 0, 1, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ceq2s"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0, 0, 1, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_tg3s4"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 0.0392157, 1, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_xss0p"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 0.0392157, 1, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_w3opq"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 0.0392157, 1, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_qwbip"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 0.0392157, 1, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_x3aop"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 0.501961, 1, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_j2m03"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.0392157, 0.501961, 1, 1)
+shader_parameter/steps = 1
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_2llro"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 0.501961, 0.501961, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_es2ea"]
+render_priority = 0
+shader = ExtResource("3_28j7b")
+shader_parameter/my_color = Color(0.501961, 0.501961, 0.501961, 1)
+shader_parameter/steps = 1
+
+[node name="Gradients" type="Node3D" node_paths=PackedStringArray("world_environment")]
+script = ExtResource("1_t2d15")
+world_environment = NodePath("WorldEnvironment")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_lqw28")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.5)
+projection = 1
+
+[node name="Label3D" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, -0.795469, 0.279246, 0)
+text = "0.0"
+horizontal_alignment = 0
+vertical_alignment = 2
+
+[node name="Label3D2" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, 0.0286667, 0.279246, 0)
+text = "1.0"
+horizontal_alignment = 2
+vertical_alignment = 2
+
+[node name="Label3D3" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, 0.0461101, 0.279246, 0)
+text = "0.0"
+horizontal_alignment = 0
+vertical_alignment = 2
+
+[node name="Label3D4" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, 0.867011, 0.279246, 0)
+text = "6.0"
+horizontal_alignment = 2
+vertical_alignment = 2
+
+[node name="Gradients_White" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+
+[node name="Gradients_Red" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, 0)
+
+[node name="0-to-HDR" parent="Gradients_Red" index="0"]
+material_override = SubResource("ShaderMaterial_bstc8")
+
+[node name="0-to-1" parent="Gradients_Red" index="1"]
+material_override = SubResource("ShaderMaterial_eljuh")
+
+[node name="Gradients_Red2" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.15, 0)
+
+[node name="0-to-HDR" parent="Gradients_Red2" index="0"]
+material_override = SubResource("ShaderMaterial_81w4g")
+
+[node name="0-to-1" parent="Gradients_Red2" index="1"]
+material_override = SubResource("ShaderMaterial_ots2d")
+
+[node name="Gradients_Red3" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0)
+
+[node name="0-to-HDR" parent="Gradients_Red3" index="0"]
+material_override = SubResource("ShaderMaterial_41i5d")
+
+[node name="0-to-1" parent="Gradients_Red3" index="1"]
+material_override = SubResource("ShaderMaterial_j0kf1")
+
+[node name="Gradients_Red4" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0)
+
+[node name="0-to-HDR" parent="Gradients_Red4" index="0"]
+material_override = SubResource("ShaderMaterial_smq08")
+
+[node name="0-to-1" parent="Gradients_Red4" index="1"]
+material_override = SubResource("ShaderMaterial_w135p")
+
+[node name="Gradients_Green" parent="." instance=ExtResource("2_p2qnr")]
+
+[node name="0-to-HDR" parent="Gradients_Green" index="0"]
+material_override = SubResource("ShaderMaterial_2wh7i")
+
+[node name="0-to-1" parent="Gradients_Green" index="1"]
+material_override = SubResource("ShaderMaterial_xj3wk")
+
+[node name="Gradients_Green2" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.05, 0)
+
+[node name="0-to-HDR" parent="Gradients_Green2" index="0"]
+material_override = SubResource("ShaderMaterial_ttmyv")
+
+[node name="0-to-1" parent="Gradients_Green2" index="1"]
+material_override = SubResource("ShaderMaterial_g72v6")
+
+[node name="Gradients_Green3" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 0)
+
+[node name="0-to-HDR" parent="Gradients_Green3" index="0"]
+material_override = SubResource("ShaderMaterial_wjnjt")
+
+[node name="0-to-1" parent="Gradients_Green3" index="1"]
+material_override = SubResource("ShaderMaterial_wm7wm")
+
+[node name="Gradients_Green4" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.15, 0)
+
+[node name="0-to-HDR" parent="Gradients_Green4" index="0"]
+material_override = SubResource("ShaderMaterial_7d5gp")
+
+[node name="0-to-1" parent="Gradients_Green4" index="1"]
+material_override = SubResource("ShaderMaterial_115u5")
+
+[node name="Gradients_Blue" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0)
+
+[node name="0-to-HDR" parent="Gradients_Blue" index="0"]
+material_override = SubResource("ShaderMaterial_g82jm")
+
+[node name="0-to-1" parent="Gradients_Blue" index="1"]
+material_override = SubResource("ShaderMaterial_ceq2s")
+
+[node name="Gradients_Blue2" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25, 0)
+
+[node name="0-to-HDR" parent="Gradients_Blue2" index="0"]
+material_override = SubResource("ShaderMaterial_tg3s4")
+
+[node name="0-to-1" parent="Gradients_Blue2" index="1"]
+material_override = SubResource("ShaderMaterial_xss0p")
+
+[node name="Gradients_Blue3" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.3, 0)
+
+[node name="0-to-HDR" parent="Gradients_Blue3" index="0"]
+material_override = SubResource("ShaderMaterial_w3opq")
+
+[node name="0-to-1" parent="Gradients_Blue3" index="1"]
+material_override = SubResource("ShaderMaterial_qwbip")
+
+[node name="Gradients_Blue4" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.35, 0)
+
+[node name="0-to-HDR" parent="Gradients_Blue4" index="0"]
+material_override = SubResource("ShaderMaterial_x3aop")
+
+[node name="0-to-1" parent="Gradients_Blue4" index="1"]
+material_override = SubResource("ShaderMaterial_j2m03")
+
+[node name="Gradients_Custom" parent="." instance=ExtResource("2_p2qnr")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.4, 0)
+
+[node name="0-to-HDR" parent="Gradients_Custom" index="0"]
+material_override = SubResource("ShaderMaterial_2llro")
+
+[node name="0-to-1" parent="Gradients_Custom" index="1"]
+material_override = SubResource("ShaderMaterial_es2ea")
+
+[node name="Label3D" parent="Gradients_Custom" index="2"]
+text = "#808080"
+
+[node name="StepsControls" type="HBoxContainer" parent="." node_paths=PackedStringArray("max_value_label")]
+offset_left = 937.0
+offset_top = 85.0
+offset_right = 1137.0
+offset_bottom = 125.0
+script = ExtResource("4_fust6")
+bars = Array[NodePath]([NodePath("../Gradients_White"), NodePath("../Gradients_Red"), NodePath("../Gradients_Red2"), NodePath("../Gradients_Red3"), NodePath("../Gradients_Red4"), NodePath("../Gradients_Green"), NodePath("../Gradients_Green2"), NodePath("../Gradients_Green3"), NodePath("../Gradients_Green4"), NodePath("../Gradients_Blue"), NodePath("../Gradients_Blue2"), NodePath("../Gradients_Blue3"), NodePath("../Gradients_Blue4"), NodePath("../Gradients_Custom")])
+max_value_label = NodePath("../Label3D4")
+colors = Array[Color]([Color(1, 1, 1, 1), Color(1, 0, 0, 1), Color(1, 0.0392157, 0.0392157, 1), Color(1, 0.501961, 0.0392157, 1), Color(1, 0.0392157, 0.501961, 1), Color(0, 1, 0, 1), Color(0.0392157, 1, 0.0392157, 1), Color(0.501961, 1, 0.0392157, 1), Color(0.0392157, 1, 0.501961, 1), Color(0, 0, 1, 1), Color(0.0392157, 0.0392157, 1, 1), Color(0.501961, 0.0392157, 1, 1), Color(0.0392157, 0.501961, 1, 1)])
+
+[node name="Label" type="Label" parent="StepsControls"]
+layout_mode = 2
+text = "Max Value"
+
+[node name="Steps" type="HSlider" parent="StepsControls"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+min_value = 1.0
+max_value = 20.0
+value = 6.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="." node_paths=PackedStringArray("custom_bar")]
+offset_left = 14.0
+offset_top = 604.0
+offset_right = 229.0
+offset_bottom = 644.0
+theme_override_constants/separation = 10
+script = ExtResource("5_kn8ml")
+custom_bar = NodePath("../Gradients_Custom")
+
+[node name="Label" type="Label" parent="HBoxContainer"]
+layout_mode = 2
+text = "Custom Color"
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="HBoxContainer"]
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+color = Color(0.501961, 0.501961, 0.501961, 1)
+
+[connection signal="value_changed" from="StepsControls/Steps" to="StepsControls" method="_on_steps_value_changed"]
+[connection signal="color_changed" from="HBoxContainer/ColorPickerButton" to="HBoxContainer" method="_on_color_picker_button_color_changed"]
+
+[editable path="Gradients_White"]
+[editable path="Gradients_Red"]
+[editable path="Gradients_Red2"]
+[editable path="Gradients_Red3"]
+[editable path="Gradients_Red4"]
+[editable path="Gradients_Green"]
+[editable path="Gradients_Green2"]
+[editable path="Gradients_Green3"]
+[editable path="Gradients_Green4"]
+[editable path="Gradients_Blue"]
+[editable path="Gradients_Blue2"]
+[editable path="Gradients_Blue3"]
+[editable path="Gradients_Blue4"]
+[editable path="Gradients_Custom"]

--- a/3d/tonemap_color_correction/gradients/gradient_bars.gd
+++ b/3d/tonemap_color_correction/gradients/gradient_bars.gd
@@ -1,0 +1,21 @@
+class_name GradientBars extends Node3D
+
+@export var sdr_bar: GeometryInstance3D
+@export var hdr_bar: GeometryInstance3D
+@export var label: Label3D
+
+func set_num_steps(steps: int) -> void:
+	var shader_mat: ShaderMaterial = hdr_bar.material_override as ShaderMaterial
+	if shader_mat:
+		shader_mat.set_shader_parameter("steps", min(1, steps))
+
+func set_color(color: Color) -> void:
+	var shader_mat: ShaderMaterial = sdr_bar.material_override as ShaderMaterial
+	if shader_mat:
+		shader_mat.set_shader_parameter("my_color", color)
+
+	shader_mat = hdr_bar.material_override as ShaderMaterial
+	if shader_mat:
+		shader_mat.set_shader_parameter("my_color", color)
+
+	label.text = "#" + color.to_html(false)

--- a/3d/tonemap_color_correction/gradients/gradient_bars.tscn
+++ b/3d/tonemap_color_correction/gradients/gradient_bars.tscn
@@ -8,6 +8,7 @@ render_priority = 0
 shader = ExtResource("2_njjq2")
 shader_parameter/my_color = Color(1, 1, 1, 1)
 shader_parameter/steps = 10
+shader_parameter/exponential_view = true
 
 [sub_resource type="QuadMesh" id="QuadMesh_p6ckv"]
 
@@ -16,6 +17,7 @@ render_priority = 0
 shader = ExtResource("2_njjq2")
 shader_parameter/my_color = Color(1, 1, 1, 1)
 shader_parameter/steps = 1
+shader_parameter/exponential_view = true
 
 [node name="Gradients" type="Node3D" node_paths=PackedStringArray("sdr_bar", "hdr_bar", "label")]
 script = ExtResource("1_idd8e")

--- a/3d/tonemap_color_correction/gradients/gradient_bars.tscn
+++ b/3d/tonemap_color_correction/gradients/gradient_bars.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=6 format=3 uid="uid://bavd54phmfgyh"]
+
+[ext_resource type="Script" path="res://gradients/gradient_bars.gd" id="1_idd8e"]
+[ext_resource type="Shader" path="res://gradients/gradient_steps.gdshader" id="2_njjq2"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_oxi6c"]
+render_priority = 0
+shader = ExtResource("2_njjq2")
+shader_parameter/my_color = Color(1, 1, 1, 1)
+shader_parameter/steps = 10
+
+[sub_resource type="QuadMesh" id="QuadMesh_p6ckv"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_tnbw4"]
+render_priority = 0
+shader = ExtResource("2_njjq2")
+shader_parameter/my_color = Color(1, 1, 1, 1)
+shader_parameter/steps = 1
+
+[node name="Gradients" type="Node3D" node_paths=PackedStringArray("sdr_bar", "hdr_bar", "label")]
+script = ExtResource("1_idd8e")
+sdr_bar = NodePath("0-to-1")
+hdr_bar = NodePath("0-to-HDR")
+label = NodePath("Label3D")
+
+[node name="0-to-HDR" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.83, 0, 0, 0, 0.043, 0, 0, 0, 1, 0.458494, 0, 0)
+material_override = SubResource("ShaderMaterial_oxi6c")
+mesh = SubResource("QuadMesh_p6ckv")
+skeleton = NodePath("../..")
+
+[node name="0-to-1" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.83, 0, 0, 0, 0.043, 0, 0, 0, 1, -0.383273, 0, 0)
+material_override = SubResource("ShaderMaterial_tnbw4")
+mesh = SubResource("QuadMesh_p6ckv")
+skeleton = NodePath("../..")
+
+[node name="Label3D" type="Label3D" parent="."]
+transform = Transform3D(0.124, 0, 0, 0, 0.124, 0, 0, 0, 0.124, -0.804691, 0.0298065, 0)
+text = "#000000"
+outline_size = 0
+horizontal_alignment = 2
+vertical_alignment = 0

--- a/3d/tonemap_color_correction/gradients/gradient_steps.gdshader
+++ b/3d/tonemap_color_correction/gradients/gradient_steps.gdshader
@@ -1,0 +1,29 @@
+shader_type spatial;
+render_mode unshaded;
+
+uniform vec3 my_color : source_color = vec3(1.0, 1.0, 1.0);
+uniform int steps : hint_range(1, 20);
+
+void fragment() {
+	// Draw base color
+	ALBEDO = my_color;
+	
+	if (UV.y > 0.25)
+	{
+		// Draw gradient
+		 ALBEDO *= UV.x * float(steps);
+	}
+	else
+	{
+		// Draw step separation bars
+		for (int i = 1; i < steps; i++)
+		{
+			float threshold = 0.002; // Bar size
+			float target = float(i) / float(steps);
+			if (UV.x < target + threshold && UV.x > target - threshold)
+			{
+				ALBEDO = vec3(0); // Bars are colored black
+			}
+		}
+	}
+}

--- a/3d/tonemap_color_correction/gradients/gradient_steps.gdshader
+++ b/3d/tonemap_color_correction/gradients/gradient_steps.gdshader
@@ -3,6 +3,7 @@ render_mode unshaded;
 
 uniform vec3 my_color : source_color = vec3(1.0, 1.0, 1.0);
 uniform int steps : hint_range(1, 20);
+uniform bool exponential_view = true;
 
 void fragment() {
 	// Draw base color
@@ -11,7 +12,14 @@ void fragment() {
 	if (UV.y > 0.25)
 	{
 		// Draw gradient
-		 ALBEDO *= UV.x * float(steps);
+		float scale = UV.x * float(steps);
+		
+		if (exponential_view)
+		{
+			scale = (scale * scale) / float(steps);
+		}
+		
+		ALBEDO *= scale;
 	}
 	else
 	{
@@ -19,7 +27,15 @@ void fragment() {
 		for (int i = 1; i < steps; i++)
 		{
 			float threshold = 0.002; // Bar size
-			float target = float(i) / float(steps);
+			float target = float(i);
+			
+			if (exponential_view)
+			{
+				target = sqrt(float(i) * float(steps));
+			}
+			
+			target = target / float(steps);
+			
 			if (UV.x < target + threshold && UV.x > target - threshold)
 			{
 				ALBEDO = vec3(0); // Bars are colored black

--- a/3d/tonemap_color_correction/gradients/gradients_controls.gd
+++ b/3d/tonemap_color_correction/gradients/gradients_controls.gd
@@ -4,6 +4,7 @@ extends Node
 @export var max_value_label: Label3D
 @export var colors: Array[Color]
 @export var custom_bar: GradientBars
+@export var hues: MeshInstance3D
 
 func _ready():
 	for i in range(colors.size()):
@@ -22,10 +23,14 @@ func _on_steps_value_changed(value):
 		var bar = get_node(bar_path)
 		var shader_mat = bar.hdr_bar.material_override as ShaderMaterial
 		shader_mat.set_shader_parameter("steps", value)
+	if hues:
+		var shader_mat = hues.material_override as ShaderMaterial
+		shader_mat.set_shader_parameter("steps", value)
 
 
 func _on_color_picker_button_color_changed(color):
-	custom_bar.set_color(color)
+	if custom_bar:
+		custom_bar.set_color(color)
 
 
 func _on_exponential_toggled(button_pressed):
@@ -35,4 +40,7 @@ func _on_exponential_toggled(button_pressed):
 		shader_mat.set_shader_parameter("exponential_view", button_pressed)
 
 		shader_mat = bar.sdr_bar.material_override as ShaderMaterial
+		shader_mat.set_shader_parameter("exponential_view", button_pressed)
+	if hues:
+		var shader_mat = hues.material_override as ShaderMaterial
 		shader_mat.set_shader_parameter("exponential_view", button_pressed)

--- a/3d/tonemap_color_correction/gradients/gradients_controls.gd
+++ b/3d/tonemap_color_correction/gradients/gradients_controls.gd
@@ -1,8 +1,9 @@
-extends HBoxContainer
+extends Node
 
 @export var bars: Array[NodePath]
 @export var max_value_label: Label3D
 @export var colors: Array[Color]
+@export var custom_bar: GradientBars
 
 func _ready():
 	for i in range(colors.size()):
@@ -12,6 +13,8 @@ func _ready():
 		bar.set_color(col)
 
 	_on_steps_value_changed(6)
+	_on_color_picker_button_color_changed(Color(0.5, 0.5, 0.5, 1))
+	_on_exponential_toggled(false)
 
 func _on_steps_value_changed(value):
 	max_value_label.text = "%.1f" % value
@@ -19,3 +22,17 @@ func _on_steps_value_changed(value):
 		var bar = get_node(bar_path)
 		var shader_mat = bar.hdr_bar.material_override as ShaderMaterial
 		shader_mat.set_shader_parameter("steps", value)
+
+
+func _on_color_picker_button_color_changed(color):
+	custom_bar.set_color(color)
+
+
+func _on_exponential_toggled(button_pressed):
+	for bar_path in bars:
+		var bar = get_node(bar_path)
+		var shader_mat = bar.hdr_bar.material_override as ShaderMaterial
+		shader_mat.set_shader_parameter("exponential_view", button_pressed)
+
+		shader_mat = bar.sdr_bar.material_override as ShaderMaterial
+		shader_mat.set_shader_parameter("exponential_view", button_pressed)

--- a/3d/tonemap_color_correction/gradients/gradients_controls.gd
+++ b/3d/tonemap_color_correction/gradients/gradients_controls.gd
@@ -1,0 +1,21 @@
+extends HBoxContainer
+
+@export var bars: Array[NodePath]
+@export var max_value_label: Label3D
+@export var colors: Array[Color]
+
+func _ready():
+	for i in range(colors.size()):
+		var bar_path: NodePath = bars[i]
+		var bar: GradientBars = get_node(bar_path) as GradientBars
+		var col: Color = colors[i]
+		bar.set_color(col)
+
+	_on_steps_value_changed(6)
+
+func _on_steps_value_changed(value):
+	max_value_label.text = "%.1f" % value
+	for bar_path in bars:
+		var bar = get_node(bar_path)
+		var shader_mat = bar.hdr_bar.material_override as ShaderMaterial
+		shader_mat.set_shader_parameter("steps", value)

--- a/3d/tonemap_color_correction/gradients/gradients_custom_color.gd
+++ b/3d/tonemap_color_correction/gradients/gradients_custom_color.gd
@@ -1,0 +1,9 @@
+extends HBoxContainer
+
+@export var custom_bar: GradientBars
+
+func _ready():
+	_on_color_picker_button_color_changed(Color(0.5, 0.5, 0.5, 1))
+
+func _on_color_picker_button_color_changed(color):
+	custom_bar.set_color(color)

--- a/3d/tonemap_color_correction/gradients/gradients_custom_color.gd
+++ b/3d/tonemap_color_correction/gradients/gradients_custom_color.gd
@@ -1,9 +1,0 @@
-extends HBoxContainer
-
-@export var custom_bar: GradientBars
-
-func _ready():
-	_on_color_picker_button_color_changed(Color(0.5, 0.5, 0.5, 1))
-
-func _on_color_picker_button_color_changed(color):
-	custom_bar.set_color(color)

--- a/3d/tonemap_color_correction/gradients/hues.gdshader
+++ b/3d/tonemap_color_correction/gradients/hues.gdshader
@@ -1,0 +1,84 @@
+shader_type spatial;
+render_mode unshaded;
+
+uniform int steps : hint_range(1, 20);
+uniform bool exponential_view = true;
+
+void fragment() {
+	float top_bar = 0.01;
+	if (UV.y >= top_bar)
+	{
+		float padding = 0.002;
+		float y = (UV.y - top_bar - padding) / (1.0 - top_bar - padding * 2.0);
+		y = clamp(y, 0.0, 1.0);
+		float segments = 1.0 / 6.0;
+		vec3 col = vec3(0);
+		if (y < segments)
+		{
+			col.r = 1.0;
+			col.g = y / segments;
+			col.b = 0.0;
+		}
+		else if (y < segments * 2.0)
+		{
+			col.r = (y - segments * 2.0) / -segments;
+			col.g = 1.0;
+			col.b = 0.0;
+		}
+		else if (y < segments * 3.0)
+		{
+			col.r = 0.0;
+			col.g = 1.0;
+			col.b = (y - segments * 2.0) / segments;
+		}
+		else if (y < segments * 4.0)
+		{
+			col.r = 0.0;
+			col.g = (y - segments * 4.0) / -segments;
+			col.b = 1.0;
+		}
+		else if (y < segments * 5.0)
+		{
+			col.r = (y - segments * 4.0) / segments;
+			col.g = 0.0;
+			col.b = 1.0;
+		}
+		else
+		{
+			col.r = 1.0;
+			col.g = 0.0;
+			col.b = (y - segments * 6.0) / -segments;
+		}
+		
+		float scale = UV.x * float(steps);
+		
+		if (exponential_view)
+		{
+			scale = (scale * scale) / float(steps);
+		}
+		
+		ALBEDO = col * scale;
+	}
+	else
+	{
+		ALBEDO = vec3(1.0);
+		// Draw step separation bars
+		for (int i = 1; i < steps; i++)
+		{
+			float threshold = 0.002; // Bar size
+			float target = float(i);
+			
+			if (exponential_view)
+			{
+				target = sqrt(float(i) * float(steps));
+			}
+			
+			target = target / float(steps);
+			
+			if (UV.x < target + threshold && UV.x > target - threshold)
+			{
+				ALBEDO = vec3(0); // Bars are colored black
+			}
+		}
+	}
+}

--- a/3d/tonemap_color_correction/hues.tscn
+++ b/3d/tonemap_color_correction/hues.tscn
@@ -1,0 +1,91 @@
+[gd_scene load_steps=7 format=3 uid="uid://c52ta7ygsn7wv"]
+
+[ext_resource type="Script" path="res://test_scene.gd" id="1_oue8n"]
+[ext_resource type="Shader" path="res://gradients/hues.gdshader" id="2_dw6v8"]
+[ext_resource type="Script" path="res://gradients/gradients_controls.gd" id="4_jldl5"]
+
+[sub_resource type="Environment" id="Environment_lqw28"]
+background_mode = 1
+background_energy_multiplier = 0.0
+ambient_light_source = 1
+reflected_light_source = 1
+tonemap_white = 6.0
+glow_intensity = 0.09
+glow_blend_mode = 1
+fog_density = 0.025
+adjustment_enabled = true
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_2qf08"]
+render_priority = 0
+shader = ExtResource("2_dw6v8")
+shader_parameter/steps = 1
+shader_parameter/exponential_view = false
+
+[sub_resource type="QuadMesh" id="QuadMesh_06xbs"]
+
+[node name="Gradients" type="Node3D" node_paths=PackedStringArray("world_environment")]
+script = ExtResource("1_oue8n")
+world_environment = NodePath("WorldEnvironment")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_lqw28")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.5)
+projection = 1
+
+[node name="Label3D" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, -0.873761, 0.279246, 0)
+text = "0.0"
+horizontal_alignment = 0
+vertical_alignment = 2
+
+[node name="Label3D4" type="Label3D" parent="."]
+transform = Transform3D(0.15, 0, 0, 0, 0.15, 0, 0, 0, 0.15, 0.867011, 0.279246, 0)
+text = "6.0"
+horizontal_alignment = 2
+vertical_alignment = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1.7376, 0, 0, 0, 0.707668, 0, 0, 0, 1, 0, -0.0814103, 0)
+material_override = SubResource("ShaderMaterial_2qf08")
+mesh = SubResource("QuadMesh_06xbs")
+
+[node name="Controls" type="Node" parent="." node_paths=PackedStringArray("max_value_label", "custom_bar", "hues")]
+script = ExtResource("4_jldl5")
+max_value_label = NodePath("../Label3D4")
+custom_bar = NodePath("")
+hues = NodePath("../MeshInstance3D")
+
+[node name="StepsControls" type="HBoxContainer" parent="Controls"]
+offset_left = 937.0
+offset_top = 85.0
+offset_right = 1137.0
+offset_bottom = 125.0
+
+[node name="Label" type="Label" parent="Controls/StepsControls"]
+layout_mode = 2
+text = "Max Value"
+
+[node name="Steps" type="HSlider" parent="Controls/StepsControls"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+min_value = 1.0
+max_value = 20.0
+value = 6.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Controls"]
+offset_left = 14.0
+offset_top = 604.0
+offset_right = 420.0
+offset_bottom = 644.0
+theme_override_constants/separation = 10
+
+[node name="Exponential" type="CheckButton" parent="Controls/HBoxContainer"]
+layout_mode = 2
+tooltip_text = "Uses a power 2 exponential function. This allows for easier viewing of the darker range of values."
+text = "Exponential Scale"
+
+[connection signal="value_changed" from="Controls/StepsControls/Steps" to="Controls" method="_on_steps_value_changed"]
+[connection signal="toggled" from="Controls/HBoxContainer/Exponential" to="Controls" method="_on_exponential_toggled"]

--- a/3d/tonemap_color_correction/options.gd
+++ b/3d/tonemap_color_correction/options.gd
@@ -1,6 +1,34 @@
 extends VBoxContainer
 
-@export var world_environment: WorldEnvironment
+@export var scenes: Array[PackedScene]
+
+var current_scene: TestScene = null
+var world_environment: WorldEnvironment = null
+
+func _ready():
+	_on_scene_option_button_item_selected(0)
+
+func _on_scene_option_button_item_selected(index):
+	if current_scene != null:
+		current_scene.queue_free()
+		current_scene = null
+
+	var old_environment: Environment = null
+	if world_environment != null:
+		old_environment = world_environment.environment
+
+	var new_scene: PackedScene = scenes[index]
+	current_scene = new_scene.instantiate() as TestScene
+	if current_scene:
+		add_child(current_scene)
+
+		world_environment = current_scene.world_environment
+		if old_environment != null:
+			world_environment.environment.tonemap_mode = old_environment.tonemap_mode
+			world_environment.environment.tonemap_exposure = old_environment.tonemap_exposure
+			world_environment.environment.tonemap_white = old_environment.tonemap_white
+			world_environment.environment.adjustment_color_correction = old_environment.adjustment_color_correction
+			world_environment.environment.adjustment_saturation = old_environment.adjustment_saturation
 
 
 func _on_tonemap_mode_item_selected(index: int) -> void:

--- a/3d/tonemap_color_correction/test.tscn
+++ b/3d/tonemap_color_correction/test.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://c364yor2q0j1a"]
+[gd_scene load_steps=4 format=3 uid="uid://bulw0pypka0bv"]
 
 [ext_resource type="Script" path="res://options.gd" id="1_20y27"]
 [ext_resource type="PackedScene" uid="uid://bfbqknlrqre0c" path="res://3d_primitives.tscn" id="2_leeh8"]
+[ext_resource type="PackedScene" uid="uid://drmdg7kgtgadn" path="res://gradients.tscn" id="3_py7p5"]
 
 [node name="Node3D" type="Node3D"]
 
@@ -11,7 +12,7 @@ offset_top = 16.0
 offset_right = 576.0
 offset_bottom = 82.0
 script = ExtResource("1_20y27")
-scenes = Array[PackedScene]([ExtResource("2_leeh8")])
+scenes = Array[PackedScene]([ExtResource("2_leeh8"), ExtResource("3_py7p5")])
 
 [node name="TonemapMode" type="HBoxContainer" parent="Options"]
 layout_mode = 2
@@ -23,10 +24,12 @@ text = "Scene"
 
 [node name="SceneOptionButton" type="OptionButton" parent="Options/TonemapMode"]
 layout_mode = 2
-item_count = 1
+item_count = 2
 selected = 0
 popup/item_0/text = "3D Primitives"
 popup/item_0/id = 0
+popup/item_1/text = "Gradients"
+popup/item_1/id = 1
 
 [node name="Label" type="Label" parent="Options/TonemapMode"]
 layout_mode = 2

--- a/3d/tonemap_color_correction/test.tscn
+++ b/3d/tonemap_color_correction/test.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://bulw0pypka0bv"]
+[gd_scene load_steps=5 format=3 uid="uid://bulw0pypka0bv"]
 
 [ext_resource type="Script" path="res://options.gd" id="1_20y27"]
 [ext_resource type="PackedScene" uid="uid://bfbqknlrqre0c" path="res://3d_primitives.tscn" id="2_leeh8"]
 [ext_resource type="PackedScene" uid="uid://drmdg7kgtgadn" path="res://gradients.tscn" id="3_py7p5"]
+[ext_resource type="PackedScene" uid="uid://c52ta7ygsn7wv" path="res://hues.tscn" id="4_pbomq"]
 
 [node name="Node3D" type="Node3D"]
 
@@ -12,7 +13,7 @@ offset_top = 16.0
 offset_right = 576.0
 offset_bottom = 82.0
 script = ExtResource("1_20y27")
-scenes = Array[PackedScene]([ExtResource("2_leeh8"), ExtResource("3_py7p5")])
+scenes = Array[PackedScene]([ExtResource("2_leeh8"), ExtResource("3_py7p5"), ExtResource("4_pbomq")])
 
 [node name="TonemapMode" type="HBoxContainer" parent="Options"]
 layout_mode = 2
@@ -24,12 +25,14 @@ text = "Scene"
 
 [node name="SceneOptionButton" type="OptionButton" parent="Options/TonemapMode"]
 layout_mode = 2
-item_count = 2
+item_count = 3
 selected = 0
 popup/item_0/text = "3D Primitives"
 popup/item_0/id = 0
 popup/item_1/text = "Gradients"
 popup/item_1/id = 1
+popup/item_2/text = "Hues"
+popup/item_2/id = 2
 
 [node name="Label" type="Label" parent="Options/TonemapMode"]
 layout_mode = 2

--- a/3d/tonemap_color_correction/test.tscn
+++ b/3d/tonemap_color_correction/test.tscn
@@ -1,274 +1,32 @@
-[gd_scene load_steps=26 format=3 uid="uid://c364yor2q0j1a"]
+[gd_scene load_steps=3 format=3 uid="uid://c364yor2q0j1a"]
 
 [ext_resource type="Script" path="res://options.gd" id="1_20y27"]
-
-[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_y6uuk"]
-sky_top_color = Color(0, 0, 0, 1)
-sky_horizon_color = Color(0.1984, 0.242987, 0.32, 1)
-ground_bottom_color = Color(0.156863, 0.160784, 0.2, 1)
-ground_horizon_color = Color(0.156863, 0.160784, 0.2, 1)
-sun_angle_max = 6.0
-sun_curve = 3.51379
-
-[sub_resource type="Sky" id="Sky_lexvt"]
-sky_material = SubResource("ProceduralSkyMaterial_y6uuk")
-
-[sub_resource type="Environment" id="Environment_lqw28"]
-background_mode = 2
-sky = SubResource("Sky_lexvt")
-tonemap_mode = 2
-tonemap_white = 6.0
-glow_enabled = true
-glow_intensity = 0.09
-glow_blend_mode = 1
-fog_enabled = true
-fog_density = 0.025
-fog_aerial_perspective = 1.0
-adjustment_enabled = true
-
-[sub_resource type="BoxMesh" id="BoxMesh_ff240"]
-size = Vector3(512, 1, 512)
-
-[sub_resource type="Gradient" id="Gradient_sho7j"]
-offsets = PackedFloat32Array(0.260163, 0.398374, 0.536585, 0.699187, 0.829268, 1)
-colors = PackedColorArray(0.336608, 0.336608, 0.336608, 1, 0.589096, 0.589095, 0.589096, 1, 0.521141, 0.52114, 0.521141, 1, 0.762404, 0.762404, 0.762403, 1, 0.48179, 0.48179, 0.481789, 1, 1, 1, 1, 1)
-
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_dm8vr"]
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_hbgko"]
-width = 1024
-height = 1024
-seamless = true
-color_ramp = SubResource("Gradient_sho7j")
-noise = SubResource("FastNoiseLite_dm8vr")
-
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_mq5hl"]
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_tdt10"]
-width = 1024
-height = 1024
-seamless = true
-as_normal_map = true
-bump_strength = 10.0
-noise = SubResource("FastNoiseLite_mq5hl")
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4ldfp"]
-albedo_texture = SubResource("NoiseTexture2D_hbgko")
-normal_enabled = true
-normal_texture = SubResource("NoiseTexture2D_tdt10")
-uv1_scale = Vector3(512, 256, 1)
-texture_filter = 5
-
-[sub_resource type="BoxMesh" id="BoxMesh_6wvpc"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_l4mxj"]
-albedo_color = Color(0, 0, 0, 1)
-emission_enabled = true
-emission = Color(2, 1.5, 1, 1)
-
-[sub_resource type="SphereMesh" id="SphereMesh_qnmea"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kssqo"]
-metallic = 1.0
-roughness = 0.0
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4geml"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_3eq2w"]
-metallic = 1.0
-roughness = 0.5
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_uqci1"]
-albedo_color = Color(0.501961, 0.501961, 0.501961, 1)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8sl4i"]
-albedo_color = Color(0.501961, 0.501961, 0.501961, 1)
-metallic = 1.0
-roughness = 0.5
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pauuc"]
-albedo_color = Color(1, 0.25098, 0.25098, 1)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8w4e2"]
-albedo_color = Color(1, 0.25098, 0.25098, 1)
-metallic = 1.0
-roughness = 0.5
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_cb5og"]
-albedo_color = Color(0.25098, 1, 0.25098, 1)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ah8ww"]
-albedo_color = Color(0.25098, 1, 0.25098, 1)
-metallic = 1.0
-roughness = 0.5
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ako3b"]
-albedo_color = Color(0.25098, 0.25098, 1, 1)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_suuj5"]
-albedo_color = Color(0.25098, 0.25098, 1, 1)
-metallic = 1.0
-roughness = 0.5
+[ext_resource type="PackedScene" uid="uid://bfbqknlrqre0c" path="res://3d_primitives.tscn" id="2_leeh8"]
 
 [node name="Node3D" type="Node3D"]
 
-[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
-transform = Transform3D(0.866126, 0.13782, -0.480448, 0.0352591, 0.941991, 0.333781, 0.49858, -0.306037, 0.811024, -2.58974, 2.10013, -4.66397)
-light_color = Color(0.776471, 0.917647, 1, 1)
-light_energy = 0.4
-shadow_enabled = true
-shadow_bias = 0.04
-shadow_blur = 2.0
-directional_shadow_mode = 0
-directional_shadow_fade_start = 1.0
-directional_shadow_max_distance = 12.0
-
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource("Environment_lqw28")
-
-[node name="Ground" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, -0.4, 1)
-mesh = SubResource("BoxMesh_ff240")
-surface_material_override/0 = SubResource("StandardMaterial3D_4ldfp")
-
-[node name="Testers" type="Node3D" parent="."]
-
-[node name="GlowingBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_l4mxj")
-
-[node name="OmniLight3D" type="OmniLight3D" parent="Testers/GlowingBox"]
-light_energy = 2.0
-shadow_blur = 2.0
-
-[node name="GlowingSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_l4mxj")
-
-[node name="OmniLight3D" type="OmniLight3D" parent="Testers/GlowingSphere"]
-light_energy = 2.0
-shadow_blur = 2.0
-
-[node name="MirrorSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_kssqo")
-
-[node name="WhiteBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_4geml")
-
-[node name="WhiteSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_4geml")
-
-[node name="WhiteMetallicSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_3eq2w")
-
-[node name="GrayBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_uqci1")
-
-[node name="GraySphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_uqci1")
-
-[node name="GrayMetallicSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_8sl4i")
-
-[node name="RedBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_pauuc")
-
-[node name="RedSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_pauuc")
-
-[node name="RedMetallicSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_8w4e2")
-
-[node name="GreenBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_cb5og")
-
-[node name="GreenSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_cb5og")
-
-[node name="GreenMetallicSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_ah8ww")
-
-[node name="BlueBox" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0.5, 0)
-mesh = SubResource("BoxMesh_6wvpc")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_ako3b")
-
-[node name="BlueSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1.5, 0)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_ako3b")
-
-[node name="BlueMetallicSphere" type="MeshInstance3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 2.5, -1)
-mesh = SubResource("SphereMesh_qnmea")
-skeleton = NodePath("../..")
-surface_material_override/0 = SubResource("StandardMaterial3D_suuj5")
-
-[node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(0.942327, -0.0710023, 0.327076, 6.57846e-09, 0.977239, 0.212141, -0.334694, -0.199906, 0.920879, 0.669204, 2.35, 4.04922)
-fov = 50.0
-
-[node name="ReflectionProbe" type="ReflectionProbe" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 2, 0)
-size = Vector3(512, 512, 512)
-enable_shadows = true
-
-[node name="Options" type="VBoxContainer" parent="." node_paths=PackedStringArray("world_environment")]
+[node name="Options" type="VBoxContainer" parent="."]
 offset_left = 16.0
 offset_top = 16.0
 offset_right = 576.0
 offset_bottom = 82.0
 script = ExtResource("1_20y27")
-world_environment = NodePath("../WorldEnvironment")
+scenes = Array[PackedScene]([ExtResource("2_leeh8")])
 
 [node name="TonemapMode" type="HBoxContainer" parent="Options"]
 layout_mode = 2
 theme_override_constants/separation = 15
+
+[node name="SceneLabel" type="Label" parent="Options/TonemapMode"]
+layout_mode = 2
+text = "Scene"
+
+[node name="SceneOptionButton" type="OptionButton" parent="Options/TonemapMode"]
+layout_mode = 2
+item_count = 1
+selected = 0
+popup/item_0/text = "3D Primitives"
+popup/item_0/id = 0
 
 [node name="Label" type="Label" parent="Options/TonemapMode"]
 layout_mode = 2
@@ -428,6 +186,7 @@ size_flags_horizontal = 0
 button_pressed = true
 text = "Debanding"
 
+[connection signal="item_selected" from="Options/TonemapMode/SceneOptionButton" to="Options" method="_on_scene_option_button_item_selected"]
 [connection signal="item_selected" from="Options/TonemapMode/OptionButton" to="Options" method="_on_tonemap_mode_item_selected"]
 [connection signal="value_changed" from="Options/TonemapMode/Exposure/HSlider" to="Options" method="_on_exposure_value_changed"]
 [connection signal="value_changed" from="Options/TonemapMode/Whitepoint/HSlider" to="Options" method="_on_whitepoint_value_changed"]

--- a/3d/tonemap_color_correction/test_scene.gd
+++ b/3d/tonemap_color_correction/test_scene.gd
@@ -1,0 +1,3 @@
+class_name TestScene extends Node3D
+
+@export var world_environment: WorldEnvironment


### PR DESCRIPTION
This PR adds a new "Gradients" scene to the color correction and tone mapping domo. This scene allows the user to see how different tone mappers behave over a range of values, which helps identify issues with hue shift, etc.

![image](https://github.com/user-attachments/assets/7742a94e-647a-4ed1-b5a4-aa38b8737ab4)
![image](https://github.com/user-attachments/assets/064bdbbb-b84c-401a-90a0-2e7a2e0d9c7f)
![image](https://github.com/user-attachments/assets/2f3cfa6c-4140-4cd5-af81-b98cced2eeb4)
![image](https://github.com/user-attachments/assets/b4795ae5-7ac1-4b10-9725-b9984d07a9a7)
